### PR TITLE
Saturate whites for color dodge

### DIFF
--- a/color-dodge.glsl
+++ b/color-dodge.glsl
@@ -1,5 +1,5 @@
 float blendColorDodge(float base, float blend) {
-	return (blend==1.0)?blend:min(base/(1.0-blend),1.0);
+	return (blend>=1.0)?1.0:min(base/(1.0-blend),1.0);
 }
 
 vec3 blendColorDodge(vec3 base, vec3 blend) {


### PR DESCRIPTION
According to https://en.wikipedia.org/wiki/Blend_modes#Dodge_and_burn

> Blending any color with white gives white. Blending with black does not change the image. The operation is not invertible due to possible clipping of highlights.

As was written, with an equality, blending with values > 1 produces strange results:

Base:
![screen shot 2018-02-28 at 09 54 37](https://user-images.githubusercontent.com/2529989/36794334-0e63315c-1c6e-11e8-8775-e56f594f5cba.png)

Blend:
![screen shot 2018-02-28 at 09 54 45](https://user-images.githubusercontent.com/2529989/36794358-18a6d0ec-1c6e-11e8-9041-94f35ee69da2.png)
Which is a procedurally generated sun that has many `r` and `g` values > 1.

Result (with `opacity = 0.5`):
![screen shot 2018-02-28 at 09 54 14](https://user-images.githubusercontent.com/2529989/36794365-1e365a1e-1c6e-11e8-9f1d-22fc3e351aa3.png)

Replacing the conditional in line 2 with: `blend>=1.0`:
![screen shot 2018-02-28 at 09 55 25](https://user-images.githubusercontent.com/2529989/36794386-303a56b6-1c6e-11e8-9267-e8b195a84c63.png)

Which is kinda cool, but still probably not what is wanted, as the color should saturate at white and `opacity = 0.5` here means that at *most* a 50% grey should be added from the blended image. Finally with line 2 reading `(blend>1.0)?1.0:`... : 
![screen shot 2018-02-28 at 09 55 34](https://user-images.githubusercontent.com/2529989/36794454-6394a566-1c6e-11e8-94db-fefc26812c45.png)

Which is how I believe the blending would work in photo editing software.