### PR TITLE
[v2] shader-ast simplifications/refactorings

### DIFF
--- a/examples/shader-ast.ts
+++ b/examples/shader-ast.ts
@@ -9,6 +9,7 @@ import {
   Texture,
   TextureFormat,
   TextureTarget,
+  setLogger,
 } from "@thi.ng/webgl";
 import {
   $xy,
@@ -20,8 +21,12 @@ import {
   texture,
   vec4,
 } from "@thi.ng/shader-ast";
+import { ConsoleLogger } from "@thi.ng/api";
 import { stream, sync, fromDOMEvent } from "@thi.ng/rstream";
 import { blendModeSelect3, blendModeSelect4, BLEND_MODES_3 } from "../src";
+
+// enable logger to see generated GLSL output
+setLogger(new ConsoleLogger("webgl"));
 
 const fromImage = (gl: WebGLRenderingContext, url: string) =>
   stream<Texture>(($) => {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "typescript": "^4.2.2"
   },
   "dependencies": {
+    "@thi.ng/api": "^7.0.0",
     "@thi.ng/shader-ast": "^0.8.0",
     "@thi.ng/shader-ast-glsl": "^0.2.22"
   }

--- a/src/all-blend.ts
+++ b/src/all-blend.ts
@@ -1,26 +1,20 @@
-import { ifThen, defn, int, eq, ret } from "@thi.ng/shader-ast";
+import { defn, eq, ifThen, int, ret } from "@thi.ng/shader-ast";
+import type { BlendMode, BlendModeDef, Color } from "./api";
 import { BLEND_MODES_3, BLEND_MODES_4 } from "./constants";
 
-export const blendModeSelect3 = defn(
-  "vec3",
-  "blendModePick",
-  ["int", "vec3", "vec3", "float"],
-  (mode, base, blend, opacity) => {
-    const select = Object.values(BLEND_MODES_3).map((blendFn, i) =>
-      ifThen(eq(mode, int(i)), [ret(blendFn(base, blend, opacity))])
-    );
-    return [...select];
-  }
-);
+const blendModeSelect = <T extends Color>(
+  type: T,
+  modes: Record<BlendMode, BlendModeDef<T>>
+) =>
+  defn(
+    type,
+    "blendModePick",
+    ["int", type, type, "float"],
+    (mode, base, blend, opacity) =>
+      Object.values(modes).map((blendFn, i) =>
+        ifThen(eq(mode, int(i)), [ret(blendFn(base, blend, opacity))])
+      )
+  );
 
-export const blendModeSelect4 = defn(
-  "vec4",
-  "blendModePick",
-  ["int", "vec4", "vec4", "float"],
-  (mode, base, blend, opacity) => {
-    const select = Object.values(BLEND_MODES_4).map((blendFn, i) =>
-      ifThen(eq(mode, int(i)), [ret(blendFn(base, blend, opacity))])
-    );
-    return [...select];
-  }
-);
+export const blendModeSelect3 = blendModeSelect("vec3", BLEND_MODES_3);
+export const blendModeSelect4 = blendModeSelect("vec4", BLEND_MODES_4);

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,7 @@
-import { Term } from "@thi.ng/shader-ast";
-import { defBlendFn3, defBlendFn4 } from "./def-blend";
+import type { FloatTerm, TaggedFn3, Term } from "@thi.ng/shader-ast";
+
+export type Color = "vec3" | "vec4";
+export type ColorTerm = Term<Color>;
 
 export type BlendMode =
   | "add"
@@ -20,17 +22,19 @@ export type BlendMode =
   | "vivid-light"
   | "reflect";
 
-export type BlendModeFloat = (
-  base: Term<"float">,
-  blend: Term<"float">
-) => Term<"float">;
+export type BlendModeFloat = (base: FloatTerm, blend: FloatTerm) => FloatTerm;
 
-export type BlendModeVec<T extends "vec3" | "vec4"> = (
-  base: Term<T>,
-  blend: Term<T>
-) => Term<T>;
+export type BlendModeVec<A extends Color, B extends A = A> = (
+  base: Term<A>,
+  blend: Term<B>
+) => Term<A>;
 
-export type BlendModeDef3 = ReturnType<typeof defBlendFn3>;
-export type BlendModeDef4 = ReturnType<typeof defBlendFn4>;
+export type BlendModeVec3 = BlendModeVec<"vec3">;
+export type BlendModeVec4 = BlendModeVec<"vec4">;
+
+export type BlendModeDef<T extends Color> = TaggedFn3<T, T, "float", T>;
+
+export type BlendModeDef3 = BlendModeDef<"vec3">;
+export type BlendModeDef4 = BlendModeDef<"vec4">;
 
 export default {};

--- a/src/blend-impl.ts
+++ b/src/blend-impl.ts
@@ -2,7 +2,10 @@ import {
   abs,
   add,
   div,
-  float,
+  FLOAT0,
+  FLOAT05,
+  FLOAT1,
+  FLOAT2,
   gte,
   lt,
   lte,
@@ -10,45 +13,69 @@ import {
   min,
   mul,
   sub,
+  Term,
   ternary,
   vec3,
+  Vec3Term,
   vec4,
+  Vec4Term,
 } from "@thi.ng/shader-ast";
-import { BlendModeFloat, BlendModeVec } from "./api";
+import type {
+  BlendModeFloat,
+  BlendModeVec3,
+  BlendModeVec4,
+  ColorTerm,
+} from "./api";
 
-export const blendAddVec3: BlendModeVec<"vec3"> = (base, blend) =>
-  min(add(base, blend), vec3(1.0));
+export const blendAddVec3: BlendModeVec3 = (base, blend) =>
+  min(add(base, blend), vec3(FLOAT1));
 
-export const blendAddVec4: BlendModeVec<"vec4"> = (base, blend) =>
-  min(add(base, blend), vec4(1.0));
+export const blendAddVec4: BlendModeVec4 = (base, blend) =>
+  min(add(base, blend), vec4(FLOAT1));
 
-export const blendAverageVec: BlendModeVec<"vec3" | "vec4"> = (base, blend) =>
-  div(add(base, blend), float(2.0));
+export function blendAverageVec(base: Vec3Term, blend: Vec3Term): Vec3Term;
+export function blendAverageVec(base: Vec4Term, blend: Vec4Term): Vec4Term;
+export function blendAverageVec(base: ColorTerm, blend: ColorTerm): Term<any> {
+  return div(add(base, blend), FLOAT2);
+}
 
 export const blendColorBurnFloat: BlendModeFloat = (base, blend) =>
   ternary(
-    lte(blend, float(0.0)),
+    lte(blend, FLOAT0),
     blend,
-    max(sub(float(1.0), div(sub(float(1.0), base), blend)), float(0.0))
+    max(sub(FLOAT1, div(sub(FLOAT1, base), blend)), FLOAT0)
   );
 
 export const blendColorDodgeFloat: BlendModeFloat = (base, blend) =>
   ternary(
-    gte(blend, float(1.0)),
+    gte(blend, FLOAT1),
     blend,
-    min(div(base, sub(1.0, blend)), float(1.0))
+    min(div(base, sub(FLOAT1, blend)), FLOAT1)
   );
 
-export const blendDarkenVec: BlendModeVec<"vec3" | "vec4"> = (base, blend) =>
-  min(base, blend);
+export function blendDarkenVec(base: Vec3Term, blend: Vec3Term): Vec3Term;
+export function blendDarkenVec(base: Vec4Term, blend: Vec4Term): Vec4Term;
+export function blendDarkenVec(base: ColorTerm, blend: ColorTerm): Term<any> {
+  return min(base, blend);
+}
 
-export const blendDifferenceVec: BlendModeVec<"vec3" | "vec4"> = (
-  base,
-  blend
-) => abs(sub(base, blend));
+export function blendDifferenceVec(base: Vec3Term, blend: Vec3Term): Vec3Term;
+export function blendDifferenceVec(base: Vec4Term, blend: Vec4Term): Vec4Term;
+export function blendDifferenceVec(
+  base: ColorTerm,
+  blend: ColorTerm
+): Term<any> {
+  return abs(sub(base, blend));
+}
 
-export const blendExclusionVec: BlendModeVec<"vec3" | "vec4"> = (base, blend) =>
-  add(base, sub(blend, mul(2.0, mul(base, blend))));
+export function blendExclusionVec(base: Vec3Term, blend: Vec3Term): Vec3Term;
+export function blendExclusionVec(base: Vec4Term, blend: Vec4Term): Vec4Term;
+export function blendExclusionVec(
+  base: ColorTerm,
+  blend: ColorTerm
+): Term<any> {
+  return add(base, sub(blend, mul(FLOAT2, mul(base, blend))));
+}
 
 export const blendGlowFloat: BlendModeFloat = (base, blend) =>
   blendReflectFloat(blend, base);
@@ -57,45 +84,53 @@ export const blendHardLightFloat: BlendModeFloat = (base, blend) =>
   blendOverlayFloat(blend, base);
 
 export const blendHardMixFloat: BlendModeFloat = (base, blend) =>
-  ternary(
-    lt(blendVividLightFloat(base, blend), float(0.5)),
-    float(0.0),
-    float(1.0)
-  );
+  ternary(lt(blendVividLightFloat(base, blend), FLOAT05), FLOAT0, FLOAT1);
 
-export const blendLightenVec: BlendModeVec<"vec3" | "vec4"> = (base, blend) =>
-  max(base, blend);
+export function blendLightenVec(base: Vec3Term, blend: Vec3Term): Vec3Term;
+export function blendLightenVec(base: Vec4Term, blend: Vec4Term): Vec4Term;
+export function blendLightenVec(base: ColorTerm, blend: ColorTerm): Term<any> {
+  return max(base, blend);
+}
 
 // Linear Burn
 // Linear Dodge
 // Linear Light
 
-export const blendMultiplyVec: BlendModeVec<"vec3" | "vec4"> = (base, blend) =>
-  mul(base, blend);
+export function blendMultiplyVec(base: Vec3Term, blend: Vec3Term): Vec3Term;
+export function blendMultiplyVec(base: Vec4Term, blend: Vec4Term): Vec4Term;
+export function blendMultiplyVec(base: ColorTerm, blend: ColorTerm): Term<any> {
+  return mul(base, blend);
+}
 
-export const blendNegationVec: BlendModeVec<"vec3" | "vec4"> = (base, blend) =>
-  sub(1.0, abs(sub(1.0, sub(base, blend))));
+export function blendNegationVec(base: Vec3Term, blend: Vec3Term): Vec3Term;
+export function blendNegationVec(base: Vec4Term, blend: Vec4Term): Vec4Term;
+export function blendNegationVec(base: ColorTerm, blend: ColorTerm): Term<any> {
+  return sub(FLOAT1, abs(sub(FLOAT1, sub(base, blend))));
+}
 
-export const blendNormalVec: BlendModeVec<"vec3" | "vec4"> = (base, blend) =>
-  blend;
+export function blendNormalVec(base: Vec3Term, blend: Vec3Term): Vec3Term;
+export function blendNormalVec(base: Vec4Term, blend: Vec4Term): Vec4Term;
+export function blendNormalVec(_: ColorTerm, blend: ColorTerm): Term<any> {
+  return blend;
+}
 
 export const blendOverlayFloat: BlendModeFloat = (base, blend) =>
   ternary(
-    lt(base, float(0.5)),
-    mul(2.0, mul(base, blend)),
-    sub(1.0, mul(2.0, mul(sub(1.0, base), sub(1.0, blend))))
+    lt(base, FLOAT05),
+    mul(FLOAT2, mul(base, blend)),
+    sub(FLOAT1, mul(FLOAT2, mul(sub(FLOAT1, base), sub(FLOAT1, blend))))
   );
 
 export const blendReflectFloat: BlendModeFloat = (base, blend) =>
   ternary(
-    gte(blend, float(1.0)),
+    gte(blend, FLOAT1),
     blend,
-    min(div(mul(base, base), sub(1.0, blend)), float(1.0))
+    min(div(mul(base, base), sub(FLOAT1, blend)), FLOAT1)
   );
 
 export const blendVividLightFloat: BlendModeFloat = (base, blend) =>
   ternary(
-    lt(base, float(0.5)),
-    blendColorBurnFloat(base, mul(2.0, blend)),
-    blendColorDodgeFloat(base, mul(2.0, sub(blend, 0.5)))
+    lt(base, FLOAT05),
+    blendColorBurnFloat(base, mul(FLOAT2, blend)),
+    blendColorDodgeFloat(base, mul(FLOAT2, sub(blend, FLOAT05)))
   );

--- a/src/def-blend.ts
+++ b/src/def-blend.ts
@@ -1,4 +1,13 @@
-import { add, defn, mul, ret, sub } from "@thi.ng/shader-ast";
+import type { Fn2 } from "@thi.ng/api";
+import {
+  add,
+  defn,
+  FloatSym,
+  mul,
+  ret,
+  ScopeBody,
+  sub,
+} from "@thi.ng/shader-ast";
 import type {
   BlendModeDef3,
   BlendModeDef4,
@@ -7,6 +16,11 @@ import type {
   BlendModeVec4,
   Color,
 } from "./api";
+
+export const defBlendFloat = (
+  name: string,
+  body: Fn2<FloatSym, FloatSym, ScopeBody>
+) => defn("float", name, ["float", "float"], body);
 
 export const defBlendFn = <T extends Color>(
   type: T,

--- a/src/def-blend.ts
+++ b/src/def-blend.ts
@@ -1,20 +1,27 @@
-import { add, float, sub, defn, ret, mul, Term } from "@thi.ng/shader-ast";
-import { BlendModeVec } from "./api";
+import { add, defn, mul, ret, sub } from "@thi.ng/shader-ast";
+import type {
+  BlendModeDef3,
+  BlendModeDef4,
+  BlendModeVec,
+  BlendModeVec3,
+  BlendModeVec4,
+  Color,
+} from "./api";
 
-export const blendLayerOpacity = (
-  blendFn: BlendModeVec<"vec3" | "vec4">,
-  base: Term<"vec3" | "vec4">,
-  blend: Term<"vec3" | "vec4">,
-  opacity: Term<"float">
+export const defBlendFn = <T extends Color>(
+  type: T,
+  blendFn: BlendModeVec<T>,
+  fnName: string
 ) =>
-  add(mul(blendFn(base, blend), opacity), mul(base, sub(float(1.0), opacity)));
-
-export const defBlendFn3 = (blendFn: BlendModeVec<"vec3">, fnName: string) =>
-  defn("vec3", fnName, ["vec3", "vec3", "float"], (base, blend, opacity) => [
-    ret(blendLayerOpacity(blendFn, base, blend, opacity)),
+  defn(type, fnName, [type, type, "float"], (base, blend, opacity) => [
+    ret(add(mul(blendFn(base, blend), opacity), mul(base, sub(1, opacity)))),
   ]);
 
-export const defBlendFn4 = (blendFn: BlendModeVec<"vec4">, fnName: string) =>
-  defn("vec4", fnName, ["vec4", "vec4", "float"], (base, blend, opacity) => [
-    ret(blendLayerOpacity(blendFn, base, blend, opacity)),
-  ]);
+export const defBlendFnPair = (
+  fnName: string,
+  blend3: BlendModeVec3,
+  blend4: BlendModeVec4
+): [BlendModeDef3, BlendModeDef4] => [
+  defBlendFn("vec3", blend3, fnName),
+  defBlendFn("vec4", blend4, fnName),
+];

--- a/src/def-blend.ts
+++ b/src/def-blend.ts
@@ -33,9 +33,9 @@ export const defBlendFn = <T extends Color>(
 
 export const defBlendFnPair = (
   fnName: string,
-  blend3: BlendModeVec3,
-  blend4: BlendModeVec4
+  blend3: BlendModeVec<Color>,
+  blend4: BlendModeVec<Color> = blend3
 ): [BlendModeDef3, BlendModeDef4] => [
-  defBlendFn("vec3", blend3, fnName),
-  defBlendFn("vec4", blend4, fnName),
+  defBlendFn("vec3", <BlendModeVec3>blend3, fnName),
+  defBlendFn("vec4", <BlendModeVec4>blend4, fnName),
 ];

--- a/src/def-export.ts
+++ b/src/def-export.ts
@@ -1,79 +1,66 @@
 import {
-  blendAddVec3,
-  blendAddVec4,
+  blendAddVec,
   blendAverageVec,
-  blendColorBurnFloat,
-  blendColorDodgeFloat,
+  blendColorBurnVec,
+  blendColorDodgeVec,
   blendDarkenVec,
   blendDifferenceVec,
   blendExclusionVec,
-  blendGlowFloat,
-  blendHardLightFloat,
+  blendGlowVec,
+  blendHardLightVec,
   blendHardMixFloat,
   blendLightenVec,
   blendMultiplyVec,
   blendNegationVec,
   blendNormalVec,
-  blendOverlayFloat,
-  blendReflectFloat,
+  blendOverlayVec,
+  blendReflectVec,
   blendVividLightFloat,
 } from "./blend-impl";
 import { defBlendFnPair } from "./def-blend";
 import { blendFloatToVec3, blendFloatToVec4 } from "./float-to-vec";
 import { FN_NAMES } from "./fn-names";
 
-export const [blendAdd3, blendAdd4] = defBlendFnPair(
-  "add",
-  blendAddVec3,
-  blendAddVec4
-);
+export const [blendAdd3, blendAdd4] = defBlendFnPair("add", blendAddVec);
 
 export const [blendAverage3, blendAverage4] = defBlendFnPair(
   FN_NAMES.average,
-  blendAverageVec,
   blendAverageVec
 );
 
 export const [blendColorBurn3, blendColorBurn4] = defBlendFnPair(
   FN_NAMES["color-burn"],
-  blendFloatToVec3(blendColorBurnFloat),
-  blendFloatToVec4(blendColorBurnFloat)
+  blendColorBurnVec
 );
 
 export const [blendColorDodge3, blendColorDodge4] = defBlendFnPair(
   FN_NAMES["color-dodge"],
-  blendFloatToVec3(blendColorDodgeFloat),
-  blendFloatToVec4(blendColorDodgeFloat)
+  blendColorDodgeVec
 );
 
 export const [blendDarken3, blendDarken4] = defBlendFnPair(
   FN_NAMES.darken,
-  blendDarkenVec,
   blendDarkenVec
 );
 
 export const [blendDifference3, blendDifference4] = defBlendFnPair(
   FN_NAMES.difference,
-  blendDifferenceVec,
   blendDifferenceVec
 );
 
 export const [blendExclusion3, blendExclusion4] = defBlendFnPair(
   FN_NAMES.exclusion,
-  blendExclusionVec,
   blendExclusionVec
 );
 
 export const [blendGlow3, blendGlow4] = defBlendFnPair(
   FN_NAMES.glow,
-  blendFloatToVec3(blendGlowFloat),
-  blendFloatToVec4(blendGlowFloat)
+  blendGlowVec
 );
 
 export const [blendHardLight3, blendHardLight4] = defBlendFnPair(
   FN_NAMES["hard-light"],
-  blendFloatToVec3(blendHardLightFloat),
-  blendFloatToVec4(blendHardLightFloat)
+  blendHardLightVec
 );
 
 export const [blendHardMix3, blendHardMix4] = defBlendFnPair(
@@ -84,38 +71,32 @@ export const [blendHardMix3, blendHardMix4] = defBlendFnPair(
 
 export const [blendLighten3, blendLighten4] = defBlendFnPair(
   FN_NAMES.lighten,
-  blendLightenVec,
   blendLightenVec
 );
 
 export const [blendMultiply3, blendMultiply4] = defBlendFnPair(
   FN_NAMES.multiply,
-  blendMultiplyVec,
   blendMultiplyVec
 );
 
 export const [blendNegation3, blendNegation4] = defBlendFnPair(
   FN_NAMES.negation,
-  blendNegationVec,
   blendNegationVec
 );
 
 export const [blendNormal3, blendNormal4] = defBlendFnPair(
   FN_NAMES.normal,
-  blendNormalVec,
   blendNormalVec
 );
 
 export const [blendOverlay3, blendOverlay4] = defBlendFnPair(
   FN_NAMES.overlay,
-  blendFloatToVec3(blendOverlayFloat),
-  blendFloatToVec4(blendOverlayFloat)
+  blendOverlayVec
 );
 
 export const [blendReflect3, blendReflect4] = defBlendFnPair(
   FN_NAMES.reflect,
-  blendFloatToVec3(blendReflectFloat),
-  blendFloatToVec4(blendReflectFloat)
+  blendReflectVec
 );
 
 export const [blendVividLight3, blendVividLight4] = defBlendFnPair(

--- a/src/def-export.ts
+++ b/src/def-export.ts
@@ -1,4 +1,3 @@
-import { BlendModeVec } from "./api";
 import {
   blendAddVec3,
   blendAddVec4,
@@ -19,160 +18,108 @@ import {
   blendReflectFloat,
   blendVividLightFloat,
 } from "./blend-impl";
-import { FN_NAMES } from "./fn-names";
-import { defBlendFn3, defBlendFn4 } from "./def-blend";
+import { defBlendFnPair } from "./def-blend";
 import { blendFloatToVec3, blendFloatToVec4 } from "./float-to-vec";
+import { FN_NAMES } from "./fn-names";
 
-export const blendAdd3 = defBlendFn3(blendAddVec3, "add");
-export const blendAdd4 = defBlendFn4(blendAddVec4, "add");
-
-export const blendAverage3 = defBlendFn3(
-  blendAverageVec as BlendModeVec<"vec3">,
-  FN_NAMES.average
-);
-export const blendAverage4 = defBlendFn4(
-  blendAverageVec as BlendModeVec<"vec4">,
-  FN_NAMES.average
+export const [blendAdd3, blendAdd4] = defBlendFnPair(
+  "add",
+  blendAddVec3,
+  blendAddVec4
 );
 
-export const blendColorBurn3 = defBlendFn3(
+export const [blendAverage3, blendAverage4] = defBlendFnPair(
+  FN_NAMES.average,
+  blendAverageVec,
+  blendAverageVec
+);
+
+export const [blendColorBurn3, blendColorBurn4] = defBlendFnPair(
+  FN_NAMES["color-burn"],
   blendFloatToVec3(blendColorBurnFloat),
-  FN_NAMES["color-burn"]
+  blendFloatToVec4(blendColorBurnFloat)
 );
 
-export const blendColorBurn4 = defBlendFn4(
-  blendFloatToVec4(blendColorBurnFloat),
-  FN_NAMES["color-burn"]
-);
-
-export const blendColorDodge3 = defBlendFn3(
+export const [blendColorDodge3, blendColorDodge4] = defBlendFnPair(
+  FN_NAMES["color-dodge"],
   blendFloatToVec3(blendColorDodgeFloat),
-  FN_NAMES["color-dodge"]
+  blendFloatToVec4(blendColorDodgeFloat)
 );
 
-export const blendColorDodge4 = defBlendFn4(
-  blendFloatToVec4(blendColorDodgeFloat),
-  FN_NAMES["color-dodge"]
+export const [blendDarken3, blendDarken4] = defBlendFnPair(
+  FN_NAMES.darken,
+  blendDarkenVec,
+  blendDarkenVec
 );
 
-export const blendDarken3 = defBlendFn3(
-  blendDarkenVec as BlendModeVec<"vec3">,
-  FN_NAMES.darken
-);
-export const blendDarken4 = defBlendFn4(
-  blendDarkenVec as BlendModeVec<"vec4">,
-  FN_NAMES.darken
+export const [blendDifference3, blendDifference4] = defBlendFnPair(
+  FN_NAMES.difference,
+  blendDifferenceVec,
+  blendDifferenceVec
 );
 
-export const blendDifference3 = defBlendFn3(
-  blendDifferenceVec as BlendModeVec<"vec3">,
-  FN_NAMES.difference
-);
-export const blendDifference4 = defBlendFn4(
-  blendDifferenceVec as BlendModeVec<"vec4">,
-  FN_NAMES.difference
+export const [blendExclusion3, blendExclusion4] = defBlendFnPair(
+  FN_NAMES.exclusion,
+  blendExclusionVec,
+  blendExclusionVec
 );
 
-export const blendExclusion3 = defBlendFn3(
-  blendExclusionVec as BlendModeVec<"vec3">,
-  FN_NAMES.exclusion
-);
-export const blendExclusion4 = defBlendFn4(
-  blendExclusionVec as BlendModeVec<"vec4">,
-  FN_NAMES.exclusion
-);
-
-export const blendGlow3 = defBlendFn3(
+export const [blendGlow3, blendGlow4] = defBlendFnPair(
+  FN_NAMES.glow,
   blendFloatToVec3(blendGlowFloat),
-  FN_NAMES.glow
-);
-export const blendGlow4 = defBlendFn4(
-  blendFloatToVec4(blendGlowFloat),
-  FN_NAMES.glow
+  blendFloatToVec4(blendGlowFloat)
 );
 
-export const blendHardLight3 = defBlendFn3(
+export const [blendHardLight3, blendHardLight4] = defBlendFnPair(
+  FN_NAMES["hard-light"],
   blendFloatToVec3(blendHardLightFloat),
-  FN_NAMES["hard-light"]
-);
-export const blendHardLight4 = defBlendFn4(
-  blendFloatToVec4(blendHardLightFloat),
-  FN_NAMES["hard-light"]
+  blendFloatToVec4(blendHardLightFloat)
 );
 
-export const blendHardMix3 = defBlendFn3(
+export const [blendHardMix3, blendHardMix4] = defBlendFnPair(
+  FN_NAMES["hard-mix"],
   blendFloatToVec3(blendHardMixFloat),
-  FN_NAMES["hard-mix"]
-);
-export const blendHardMix4 = defBlendFn4(
-  blendFloatToVec4(blendHardMixFloat),
-  FN_NAMES["hard-mix"]
+  blendFloatToVec4(blendHardMixFloat)
 );
 
-export const blendLighten3 = defBlendFn3(
-  blendLightenVec as BlendModeVec<"vec3">,
-  FN_NAMES.lighten
-);
-export const blendLighten4 = defBlendFn4(
-  blendLightenVec as BlendModeVec<"vec4">,
-  FN_NAMES.lighten
+export const [blendLighten3, blendLighten4] = defBlendFnPair(
+  FN_NAMES.lighten,
+  blendLightenVec,
+  blendLightenVec
 );
 
-export const blendMultiply3 = defBlendFn3(
-  blendMultiplyVec as BlendModeVec<"vec3">,
-  FN_NAMES.multiply
-);
-export const blendMultiply4 = defBlendFn4(
-  blendMultiplyVec as BlendModeVec<"vec4">,
-  FN_NAMES.multiply
+export const [blendMultiply3, blendMultiply4] = defBlendFnPair(
+  FN_NAMES.multiply,
+  blendMultiplyVec,
+  blendMultiplyVec
 );
 
-export const blendNegation3 = defBlendFn3(
-  blendNegationVec as BlendModeVec<"vec3">,
-  FN_NAMES.negation
+export const [blendNegation3, blendNegation4] = defBlendFnPair(
+  FN_NAMES.negation,
+  blendNegationVec,
+  blendNegationVec
 );
 
-export const blendNegation4 = defBlendFn4(
-  blendNegationVec as BlendModeVec<"vec4">,
-  FN_NAMES.negation
+export const [blendNormal3, blendNormal4] = defBlendFnPair(
+  FN_NAMES.normal,
+  blendNormalVec,
+  blendNormalVec
 );
 
-export const blendNormal3 = defBlendFn3(
-  blendNormalVec as BlendModeVec<"vec3">,
-  FN_NAMES.normal
-);
-
-export const blendNormal4 = defBlendFn4(
-  blendNormalVec as BlendModeVec<"vec4">,
-  FN_NAMES.normal
-);
-
-export const blendOverlay3 = defBlendFn3(
+export const [blendOverlay3, blendOverlay4] = defBlendFnPair(
+  FN_NAMES.overlay,
   blendFloatToVec3(blendOverlayFloat),
-  FN_NAMES.overlay
+  blendFloatToVec4(blendOverlayFloat)
 );
 
-export const blendOverlay4 = defBlendFn4(
-  blendFloatToVec4(blendOverlayFloat),
-  FN_NAMES.overlay
-);
-
-export const blendReflect3 = defBlendFn3(
+export const [blendReflect3, blendReflect4] = defBlendFnPair(
+  FN_NAMES.reflect,
   blendFloatToVec3(blendReflectFloat),
-  FN_NAMES.reflect
+  blendFloatToVec4(blendReflectFloat)
 );
 
-export const blendReflect4 = defBlendFn4(
-  blendFloatToVec4(blendReflectFloat),
-  FN_NAMES.reflect
-);
-
-export const blendVividLight3 = defBlendFn3(
+export const [blendVividLight3, blendVividLight4] = defBlendFnPair(
+  FN_NAMES["vivid-light"],
   blendFloatToVec3(blendVividLightFloat),
-  FN_NAMES["vivid-light"]
-);
-
-export const blendVividLight4 = defBlendFn4(
-  blendFloatToVec4(blendVividLightFloat),
-  FN_NAMES["vivid-light"]
+  blendFloatToVec4(blendVividLightFloat)
 );


### PR DESCRIPTION
Just some refactorings for your consideration :)

- add Color/ColorTerm types
- make BlendModeVec/3/4 more strict
  - i.e. force both args to be same vec type
  - previously vec3/4 mixtures possible, but illegal in GLSL
- update fn signatures of all blend mode impls
- dedupe defBlendFn(), add defBlendFnPair()
- replace all exports in def-export.ts w/ defBlendFnPair() calls
- dedupe blendModeSelect3/4() (via HOF helper)